### PR TITLE
better use of bootstrap grid columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,19 +165,19 @@
     <div class="content-marketing">
       <div class="container">
         <div class="row marketing">
-          <div class="col-lg-3" id="marketing-reuse">
+          <div class="col-md-3 col-sm-6" id="marketing-reuse">
             <h4>Code Reuse</h4>
             <p>The best code is the code you already wrote. Use the code that reliably runs on your servers and your frontend to power your next great iOS 7 app, just like that.</p>
           </div>
-          <div class="col-lg-3" id="marketing-npm">
+          <div class="col-md-3 col-sm-6" id="marketing-npm">
             <h4>Tons of modules</h4>
             <p>In tens of thousands of modules there's a module for nearly everything you can imagine. The Node.js-compatible API allows you to use virtually every module available through <a href="//npmjs.org/">npm</a>.</p>
           </div>
-          <div class="col-lg-3" id="marketing-rapid">
+          <div class="col-md-3 col-sm-6" id="marketing-rapid">
             <h4>Rapid Innovation</h4>
             <p>Node.app provides the familiar <a href="//nodejs.org/api/">Node.js API</a> which is well documented and extremely easy to use.</p>
           </div>
-          <div class="col-lg-3" id="marketing-light">
+          <div class="col-md-3 col-sm-6" id="marketing-light">
             <h4>Low-footprint</h4>
             <p>Your customers won't even notice you aren't developing native, unless you tell them. With Node.app you are using the same fast system functions just as with normal iOS code.</p>
           </div>
@@ -187,13 +187,13 @@
     <div class="content-testimonials">
       <div class="container">
         <div class="row testimonials">
-          <div class="col-lg-6">
+          <div class="col-sm-6">
             <blockquote class="twitter-tweet"><p>Developing iOS and OSX native applications using node.js API - Awesome!</p>&mdash; Roberto S&aacute;nchez (@rsc1975) <a href="https://twitter.com/rsc1975/statuses/408320790564581376">December 4, 2013</a></blockquote>
             <blockquote class="twitter-tweet"><p>Node.app - Javascript API for iOS finally!!</p>&mdash; dylan hassinger (@dylanized) <a href="https://twitter.com/dylanized/statuses/395249068978737152">October 29, 2013</a></blockquote>
             <blockquote class="twitter-tweet"><p>Node.js for iOS - Node-like API for JavaScriptCore = AWESOME.</p>&mdash; Matias Piipari (@mz2) <a href="https://twitter.com/mz2/statuses/408644791413788672">December 5, 2013</a></blockquote>
             <blockquote class="twitter-tweet"><p>Build <a href="https://twitter.com/search?q=%23io7&amp;src=hash">#io7</a> native apps with <a href="https://twitter.com/search?q=%23nodejs&amp;src=hash">#nodejs</a>. That&#39;s a fucking good news for <a href="https://twitter.com/search?q=%23javascript&amp;src=hash">#javascript</a> developers !</p>&mdash; Florent Bourgeois (@florent_b) <a href="https://twitter.com/florent_b/statuses/408898065383575552">December 6, 2013</a></blockquote>
           </div>
-          <div class="col-lg-6">
+          <div class="col-sm-6">
             <blockquote class="twitter-tweet"><p>Node.js-y on top of JavascriptCore? This is awesome!</p>&mdash; Ron Korving (@ronkorving) <a href="https://twitter.com/ronkorving/statuses/389920558508277761">October 15, 2013</a></blockquote>
             <blockquote class="twitter-tweet"><p>This looks really interesting: <a href="https://twitter.com/search?q=%23nodejs&amp;src=hash">#nodejs</a>-like api for <a href="https://twitter.com/search?q=%23ios7&amp;src=hash">#ios7</a> and <a href="https://twitter.com/search?q=%23mavericks&amp;src=hash">#mavericks</a></p>&mdash; Keystone JS (@KeystoneJS) <a href="https://twitter.com/KeystoneJS/statuses/389886485798719488">October 14, 2013</a></blockquote>
             <blockquote class="twitter-tweet"><p><a href="https://twitter.com/periping">@periping</a> well done on the <a href="https://twitter.com/search?q=%23JavaScript&amp;src=hash">#JavaScript</a> Core Project using <a href="https://twitter.com/search?q=%23iOS7&amp;src=hash">#iOS7</a>, can&#39;t wait to see what comes out of it.</p>&mdash; Suyash Joshi (@suyashcjoshi) <a href="https://twitter.com/suyashcjoshi/statuses/389824776958525440">October 14, 2013</a></blockquote>


### PR DESCRIPTION
stops the layout from directly jumping to one column per row on viewports with less than 1200px width.
